### PR TITLE
changed I2C default channel to explicit channel 1

### DIFF
--- a/DS3231micro.py
+++ b/DS3231micro.py
@@ -23,7 +23,7 @@ class DS3231:
         self.sclPin = machine.Pin(i2cClockPin, pull = machine.Pin.PULL_UP, mode=machine.Pin.OPEN_DRAIN)
         self.sdaPin = machine.Pin(i2cDataPin, pull = machine.Pin.PULL_UP, mode=machine.Pin.OPEN_DRAIN)
         
-        self.i2cVar = machine.I2C(-1, scl=self.sclPin, sda=self.sdaPin)
+        self.i2cVar = machine.I2C(1, scl=self.sclPin, sda=self.sdaPin)
         self.i2cAddr = i2cAddr
         
     # get times functions -------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
according to https://forum.micropython.org/viewtopic.php?t=9940, there is a warning "Warning: I2C(-1, ...) is deprecated, use SoftI2C(...) instead". The change is only to use the dedicated first Bus.